### PR TITLE
creates image with gvm in root; 'go use' not persisting

### DIFF
--- a/GoDockerfile
+++ b/GoDockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:12.04
 MAINTAINER Stephanie Lingwood "stephanie@shippable.com"
 
-ADD os/ubuntu/12_04.sh /os/ubuntu/
-RUN /bin/bash -c "source /os/ubuntu/12_04.sh"
+ADD os/Ubuntu/12_04.sh /os/Ubuntu/
+RUN /bin/bash -c "source /os/Ubuntu/12_04.sh"
 
 ADD language/Go/pre.sh /language/Go/
 RUN /bin/bash -c "source /language/Go/pre.sh"

--- a/language/Go/version/1_1.sh
+++ b/language/Go/version/1_1.sh
@@ -1,11 +1,19 @@
 #!/bin/bash -e
 
-# Install Go 1.1
+# # Install Go 1.1
 echo "Installing Go 1.1..."
 . /root/.gvm/scripts/gvm && gvm install go1.1;
 
 # Activate Go
 [[ -s "/root/.gvm/scripts/gvm" ]] && source "/root/.gvm/scripts/gvm"
+
 gvm use go1.1
 
+export GVM_ROOT="/root/.gvm"
+export PATH="$PATH:/root/.gvm/bin"
+
 echo "Done installing Go 1.1"
+
+
+# from Shippable go example
+# . /root/.gvm/scripts/gvm && gvm install go1.1 --prefer-binary && gvm use go1.1 && go install -a -race std

--- a/language/Go/version/1_2.sh
+++ b/language/Go/version/1_2.sh
@@ -2,10 +2,25 @@
 
 # Install Go 1.2
 echo "Installing Go 1.2..."
-sudo su - shippable -c "source /home/shippable/.gvm/scripts/gvm && gvm install go1.2";
+. /root/.gvm/scripts/gvm && gvm install go1.2;
 
 # Activate Go
-[[ -s "/home/shippable/.gvm/scripts/gvm" ]] && source "/home/shippable/.gvm/scripts/gvm"
+[[ -s "/root/.gvm/scripts/gvm" ]] && source "/root/.gvm/scripts/gvm"
+
 gvm use go1.2
 
+export GVM_ROOT="/root/.gvm"
+export PATH="$PATH:/root/.gvm/bin"
+
 echo "Done installing Go 1.2"
+
+# old, from contractor in Indonesia; errors with:
+# -su: 1: source: not found
+# /home/shippable/.gvm/scripts/env/use: line 9: cd: /home/shippable/.gvm/archive/go: No such file or directory
+# ERROR: Version not found locally. Try 'gvm install go1.2'
+
+# sudo su - shippable -c "source /home/shippable/.gvm/scripts/gvm && gvm install go1.2";
+
+# # Activate Go
+# [[ -s "/home/shippable/.gvm/scripts/gvm" ]] && source "/home/shippable/.gvm/scripts/gvm"
+# gvm use go1.2

--- a/language/Go/version/1_3.sh
+++ b/language/Go/version/1_3.sh
@@ -2,10 +2,14 @@
 
 # Install Go 1.3
 echo "Installing Go 1.3..."
-sudo su - shippable -c "source /home/shippable/.gvm/scripts/gvm && gvm install go1.3";
+. /root/.gvm/scripts/gvm && gvm install go1.3;
 
 # Activate Go
-[[ -s "/home/shippable/.gvm/scripts/gvm" ]] && source "/home/shippable/.gvm/scripts/gvm"
+[[ -s "/root/.gvm/scripts/gvm" ]] && source "/root/.gvm/scripts/gvm"
+
 gvm use go1.3
+
+export GVM_ROOT="/root/.gvm"
+export PATH="$PATH:/root/.gvm/bin"
 
 echo "Done installing Go 1.3"

--- a/language/Go/version/1_4.sh
+++ b/language/Go/version/1_4.sh
@@ -1,11 +1,14 @@
 #!/bin/bash -e
 
 # Install Go 1.4
-echo "Installing Go 1.4..."
-sudo su - shippable -c "source /home/shippable/.gvm/scripts/gvm && gvm install go1.4";
+. /root/.gvm/scripts/gvm && gvm install go1.4;
 
 # Activate Go
-[[ -s "/home/shippable/.gvm/scripts/gvm" ]] && source "/home/shippable/.gvm/scripts/gvm"
+[[ -s "/root/.gvm/scripts/gvm" ]] && source "/root/.gvm/scripts/gvm"
+
 gvm use go1.4
+
+export GVM_ROOT="/root/.gvm"
+export PATH="$PATH:/root/.gvm/bin"
 
 echo "Done installing Go 1.4"

--- a/language/Go/version/Tip.sh
+++ b/language/Go/version/Tip.sh
@@ -2,10 +2,14 @@
 
 # Install Go tip
 echo "Installing Go tip..."
-sudo su - shippable -c "source /home/shippable/.gvm/scripts/gvm && gvm install tip";
+. /root/.gvm/scripts/gvm && gvm install tip;
 
 # Activate Go
-[[ -s "/home/shippable/.gvm/scripts/gvm" ]] && source "/home/shippable/.gvm/scripts/gvm"
+[[ -s "/root/.gvm/scripts/gvm" ]] && source "/root/.gvm/scripts/gvm"
+
 gvm use tip
+
+export GVM_ROOT="/root/.gvm"
+export PATH="$PATH:/root/.gvm/bin"
 
 echo "Done installing Go tip"


### PR DESCRIPTION
Node files worked when tested in a Dockerfile. v0.6 installs the old version of npm that came with 0.6. Recommend not updating it to a more recent npm, as it will throw this error:
Object #<Object> has no method 'tmpDir' 
at
/root/.nvm/v0.6.21/lib/node_modules/npm/node_modules/osenv/osenv.js:49
This is a known error that is on npm's end. 

Go scripts: these were modified to install as root, instead of a shippable user. gvm installs correctly, but the "go use go1.1" command is not persisting into the image. This needs fixing.  
